### PR TITLE
uri_escape the URL query string or the request won't sign correctly

### DIFF
--- a/lib/faraday_middleware/request/aws_signers_v4.rb
+++ b/lib/faraday_middleware/request/aws_signers_v4.rb
@@ -36,6 +36,8 @@ class FaradayMiddleware::AwsSignersV4 < Faraday::Middleware
 
   def call(env)
     normalize_for_net_http!(env)
+    # Escape the query string or the request won't sign correctly
+    env.url.query = Seahorse::Util.uri_escape(env.url.query) if env.url and env.url.query
     req = Request.new(env)
     @signer.sign(req)
     @app.call(env)


### PR DESCRIPTION
Fix issue #1 - properly sign requests where the URL has spaces or `+` symbols in the query string.
