### PR TITLE
Refresh instance profile credentials

### DIFF
--- a/faraday_middleware-aws-signers-v4.gemspec
+++ b/faraday_middleware-aws-signers-v4.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'faraday_middleware'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'webmock'
 end

--- a/lib/faraday_middleware/request/aws_signers_v4.rb
+++ b/lib/faraday_middleware/request/aws_signers_v4.rb
@@ -44,17 +44,16 @@ class FaradayMiddleware::AwsSignersV4 < Faraday::Middleware
   def initialize(app, options = nil)
     super(app)
 
-    credentials = options.fetch(:credentials)
-    service_name = options.fetch(:service_name)
-    region = options.fetch(:region)
-    @signer = Aws::Signers::V4.new(credentials, service_name, region)
+    @credentials = options.fetch(:credentials)
+    @service_name = options.fetch(:service_name)
+    @region = options.fetch(:region)
     @net_http = net_http?(app)
   end
 
   def call(env)
     normalize_for_net_http!(env)
     req = Request.new(env)
-    @signer.sign(req)
+    Aws::Signers::V4.new(@credentials, @service_name, @region).sign(req)
     @app.call(env)
   end
 

--- a/spec/faraday_middleware/aws_signers_v4_spec.rb
+++ b/spec/faraday_middleware/aws_signers_v4_spec.rb
@@ -48,13 +48,9 @@ describe FaradayMiddleware::AwsSignersV4 do
     end
   end
 
-  let(:params) { {} }
-
   before do
     stub_const('Faraday::VERSION', '0.9.1')
   end
-
-  subject { client.get('/account', params).body }
 
   context 'without query' do
     let(:signature) do
@@ -67,6 +63,8 @@ describe FaradayMiddleware::AwsSignersV4 do
   end
 
   context 'with query' do
+    subject { client.get('/account', params).body }
+
     context 'include space' do
       let(:signature) do
         '1fab19a15836760910137069dfe5393a758047569f5efd276e09d3f40bc8e166'
@@ -89,6 +87,8 @@ describe FaradayMiddleware::AwsSignersV4 do
   end
 
   context 'use net/http' do
+    subject { client.get('/account').body }
+
     let(:signature) do
       'a1abb29af96761771fdf914527a97acbf1cfd72cbd7a23379a5b36f5b2c9d5eb'
     end
@@ -107,5 +107,178 @@ describe FaradayMiddleware::AwsSignersV4 do
     end
 
     it { is_expected.to eq response }
+  end
+
+  context 'with InstanceProfileCredentials' do
+    let(:security_credentials_url) { 'http://169.254.169.254/latest/meta-data/iam/security-credentials/' }
+
+    let(:security_credentials_response) do
+      {
+        body: {
+          "Code"            => "Success",
+          "LastUpdated"     => "2015-11-12T00:05:53Z",
+          "Type"            => "AWS-HMAC",
+          "AccessKeyId"     => "test-access-key-id",
+          "SecretAccessKey" => "test-secret-access-key",
+          "Token"           => "test-token",
+          "Expiration"      => expiration.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        }.to_json,
+        status: 200,
+      }
+    end
+
+    let(:security_credentials_response2) do
+      {
+        body: {
+          "Code"            => "Success",
+          "LastUpdated"     => "2015-11-12T00:05:53Z",
+          "Type"            => "AWS-HMAC",
+          "AccessKeyId"     => "test-access-key-id-2",
+          "SecretAccessKey" => "test-secret-access-key-2",
+          "Token"           => "test-token-2",
+          "Expiration"      => expiration2.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        }.to_json,
+        status: 200,
+      }
+    end
+
+    let(:expected_headers) do
+      {
+        "User-Agent"           => "Faraday v0.9.1",
+        "X-Amz-Date"           => Time.now.strftime("%Y%m%dT%H%M%SZ"),
+        "Host"                 => "apigateway.us-east-1.amazonaws.com",
+        "X-Amz-Content-Sha256" => "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "X-Amz-Security-Token" => "test-token",
+        "Authorization"        => [
+          "AWS4-HMAC-SHA256 Credential=test-access-key-id/20150101/us-east-1/apigateway/aws4_request",
+          "SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-security-token",
+          "Signature=#{signature}",
+        ].join(", "),
+      }
+    end
+
+    let(:expected_headers2) do
+      {
+        "User-Agent"           => "Faraday v0.9.1",
+        "X-Amz-Date"           => Time.now.strftime("%Y%m%dT%H%M%SZ"),
+        "Host"                 => "apigateway.us-east-1.amazonaws.com",
+        "X-Amz-Content-Sha256" => "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "X-Amz-Security-Token" => "test-token-2",
+        "Authorization"        => [
+          "AWS4-HMAC-SHA256 Credential=test-access-key-id-2/20150101/us-east-1/apigateway/aws4_request",
+          "SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-security-token",
+          "Signature=#{signature2}",
+        ].join(", "),
+      }
+    end
+
+    let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+
+    let(:client) do
+      Faraday.new(url: 'https://apigateway.us-east-1.amazonaws.com') do |faraday|
+        faraday.request :aws_signers_v4,
+          credentials: Aws::InstanceProfileCredentials.new,
+          service_name: 'apigateway',
+          region: 'us-east-1'
+        faraday.response :json, :content_type => /\bjson$/
+
+        faraday.adapter :test, stubs
+      end
+    end
+
+    before do
+      stub_request(:get, security_credentials_url).to_return(
+        body: "test-iam\n",
+        status: 200,
+      )
+
+      stubs.get('/account') do |env|
+        expect(env.request_headers).to eq expected_headers
+        [200, {'Content-Type' => 'application/json'}, JSON.dump(response)]
+      end
+    end
+
+    context 'when expiration is later than or equeal to 5 minutes' do
+      let(:expiration) { Time.now + 300 }
+
+      let(:signature) do
+        '5db3e32fa139305425af96b4d8d2d1633baf4025fdf09a30c435dc6f50d841e2'
+      end
+
+      before do
+        stub_request(:get, "#{security_credentials_url}test-iam").to_return(
+          security_credentials_response
+        )
+      end
+
+      subject { client.get('/account').body }
+
+      it { is_expected.to eq response }
+    end
+
+    context 'when expiration is within 5 minutes' do
+      let!(:start_time) { Time.now }
+      let(:expiration)  { start_time + 3600 }
+      let(:expiration2) { start_time + 3600 + 3600 }
+      let(:signature) do
+        '5db3e32fa139305425af96b4d8d2d1633baf4025fdf09a30c435dc6f50d841e2'
+      end
+      let(:signature2) do
+        'c5823ad86dae5962dee6226a1b03d703f679838a627663f112c40b7534510e9f'
+      end
+
+      before do
+        stub_request(:get, "#{security_credentials_url}test-iam").to_return(
+          security_credentials_response
+        ).to_return(
+          security_credentials_response2
+        )
+      end
+
+      it do
+        expect(client.get('/account').body).to eq response
+
+        Timecop.freeze(expiration - 299)
+        stubs.get('/account') do |env|
+          expect(env.request_headers).to eq expected_headers2
+          [200, {'Content-Type' => 'application/json'}, JSON.dump(response)]
+        end
+
+        expect(client.get('/account').body).to eq response
+      end
+    end
+
+    context 'when the credential is expired' do
+      let!(:start_time) { Time.now }
+      let(:expiration)  { start_time + 3600 }
+      let(:expiration2) { start_time + 3600 + 3600 }
+      let(:signature) do
+        '5db3e32fa139305425af96b4d8d2d1633baf4025fdf09a30c435dc6f50d841e2'
+      end
+      let(:signature2) do
+        'd2c1eeb728b800bcd9ef31589f8a2c3210ff8ae61bc5444f06cb05c73c4f031b'
+      end
+
+      before do
+        stub_request(:get, "#{security_credentials_url}test-iam").to_return(
+          security_credentials_response
+        ).to_return(
+          security_credentials_response2
+        )
+      end
+
+      it do
+        expect(client.get('/account').body).to eq response
+
+        Timecop.freeze(expiration)
+
+        stubs.get('/account') do |env|
+          expect(env.request_headers).to eq expected_headers2
+          [200, {'Content-Type' => 'application/json'}, JSON.dump(response)]
+        end
+
+        expect(client.get('/account').body).to eq response
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,13 +14,14 @@ require 'faraday_middleware'
 require 'faraday_middleware/aws_signers_v4'
 require 'faraday_middleware/ext/uri_ext'
 require 'timecop'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
-  config.before(:all) do
+  config.before(:each) do
     Timecop.freeze(Time.utc(2015))
   end
 
-  config.after(:all) do
+  config.after(:each) do
     Timecop.return
   end
 end


### PR DESCRIPTION
For Amazon ES access control by IAM Role, we need to initialize `Aws::Signers::V4` per request.

I updated plugin to initialize `Aws::Signers::V4` per request https://github.com/winebarrel/faraday_middleware-aws-signers-v4/commit/a0c28a3e09fd69f19d3de084de71a4ed7d3d5ce0 and add test cases for checking the behavior of the plugin with `Aws::InstanceProfileCredentials`.  https://github.com/winebarrel/faraday_middleware-aws-signers-v4/commit/a0c28a3e09fd69f19d3de084de71a4ed7d3d5ce0

As written in [elasticsearch-ruby document](https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transport/README.md#transport-implementations), elasticsearch client instance with this middleware is initialized and lives for a long time with application.

example: elasticsearch client in rails app

``` ruby
class User < ActiveRecord::Base
  include Elasticsearch::Model

  __elasticsearch__.client = Elasticsearch::Client.new(host: 'xxx', port: 80) do |faraday|
    faraday.request :aws_signers_v4,
      credentials: Aws::InstanceProfileCredentials.new,
      service_name: 'es',
      region: 'us-east-1'

   faraday.adapter Faraday.default_adapter
```

`Aws::InstanceProfileCredentials` object has expiration of its token (approximately 1 hour).
If the token is expired or near expiration, i would be refreshed when call `credentials#credentials`.
https://github.com/aws/aws-sdk-ruby/blob/9302c46592629c5d129d553e1778f652f4a5d7a7/aws-sdk-core/lib/aws-sdk-core/refreshing_credentials.rb#L24

However, `Aws::Signers::V4` only calls `credentials#credentials` when its own initialization.
https://github.com/aws/aws-sdk-ruby/blob/d0661e756042dfebd6053c425d25c748c7ad70ac/aws-sdk-core/lib/aws-sdk-core/signers/v4.rb#L24

So we need to initialize `Aws::Singers::V4` per request so that refresh credentials like aws-sdk's request_signer plugin.
https://github.com/aws/aws-sdk-ruby/blob/a806f0b8234832411da9baa2ccb53158c4219056/aws-sdk-core/lib/aws-sdk-core/plugins/request_signer.rb#L94
https://github.com/aws/aws-sdk-ruby/blob/d0661e756042dfebd6053c425d25c748c7ad70ac/aws-sdk-core/lib/aws-sdk-core/signers/v4.rb#L8
