### PR TITLE
Add a file so that Bundler.require can work well

### DIFF
--- a/lib/faraday_middleware-aws-signers-v4.rb
+++ b/lib/faraday_middleware-aws-signers-v4.rb
@@ -1,0 +1,1 @@
+require 'faraday_middleware/aws_signers_v4'


### PR DESCRIPTION
## Background

We're using `faraday_middleware-aws-signers-v4` in our Rails app with `Bundler.require`. I think this is a standard practice of Rails apps. The problem is that we need to add `:require` option in Gemfile for Bundler to load this gem well like this:

```ruby
gem "faraday_middleware-aws-signers-v4", require: "faraday_middleware/aws_signers_v4"
```

## Result

Here is a short example to show what will change by this Pull Request.

### Before

```bash
ruby -Ilib -rbundler -e "Bundler.require; p FaradayMiddleware::AwsSignersV4"
```

Before applying the change in this Pull Request, this script raises `NameError` because `Bundler.require` does not load lib/faraday_middleware/aws_signers_v4.rb.

```
-e:1:in `<main>': uninitialized constant FaradayMiddleware (NameError)
```

### After

```bash
ruby -Ilib -rbundler -e "Bundler.require; p FaradayMiddleware::AwsSignersV4"
```

After the change, the same script gets to work well.

```
FaradayMiddleware::AwsSignersV4
```
