### PR TITLE
Switch from aws-sdk(deprecated) to aws-sdk-resources

### DIFF
--- a/faraday_middleware-aws-signers-v4.gemspec
+++ b/faraday_middleware-aws-signers-v4.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'faraday', '~> 0.9'
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk-resources', '~> 2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/faraday_middleware/aws_signers_v4.rb
+++ b/lib/faraday_middleware/aws_signers_v4.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-resources'
 require 'faraday'
 
 module FaradayMiddleware

--- a/lib/faraday_middleware/ext/uri_ext.rb
+++ b/lib/faraday_middleware/ext/uri_ext.rb
@@ -1,5 +1,5 @@
 require 'uri'
-require 'aws-sdk'
+require 'aws-sdk-resources'
 
 module URI
   def self.seahorse_encode_www_form(params)


### PR DESCRIPTION
aws-sdk-resources is the new standard AWS library

Some older libraries have dependencies on aws-sdk v1. Using aws-sdk-resources allows you to use faraday_middleware-aws-signers-v4 alongside those older libraries.

[Using v1 & v2 side by side](https://aws.amazon.com/blogs/developer/upcoming-stable-release-of-aws-sdk-for-ruby-version-2/)

This would solve https://github.com/winebarrel/faraday_middleware-aws-signers-v4/issues/4