### PR TITLE
Swap aws-sdk-resources for aws-sdk-core

### DIFF
--- a/faraday_middleware-aws-signers-v4.gemspec
+++ b/faraday_middleware-aws-signers-v4.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'faraday', '~> 0.9'
-  spec.add_dependency 'aws-sdk-resources', '~> 3.0.0.rc2'
+  spec.add_dependency 'aws-sdk-core'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/faraday_middleware/aws_signers_v4.rb
+++ b/lib/faraday_middleware/aws_signers_v4.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-resources'
+require 'aws-sdk-core'
 require 'faraday'
 
 module FaradayMiddleware

--- a/lib/faraday_middleware/aws_signers_v4_ext.rb
+++ b/lib/faraday_middleware/aws_signers_v4_ext.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk/signers/v4'
+require 'aws-sigv4/signer'
 
 module AwsSignersV4Ext
   def signed_headers(request)
@@ -6,8 +6,8 @@ module AwsSignersV4Ext
   end
 end
 
-class Aws::Signers::V4
-  unless Aws::Signers::V4 < AwsSignersV4Ext
+class Aws::Sigv4::Signer
+  unless Aws::Sigv4::Signer < AwsSignersV4Ext
     prepend AwsSignersV4Ext
   end
 end

--- a/lib/faraday_middleware/ext/uri_ext.rb
+++ b/lib/faraday_middleware/ext/uri_ext.rb
@@ -1,5 +1,5 @@
 require 'uri'
-require 'aws-sdk-resources'
+require 'aws-sdk-core'
 
 module URI
   def self.seahorse_encode_www_form(params)

--- a/lib/faraday_middleware/request/aws_signers_v4.rb
+++ b/lib/faraday_middleware/request/aws_signers_v4.rb
@@ -53,7 +53,7 @@ class FaradayMiddleware::AwsSignersV4 < Faraday::Middleware
   def call(env)
     normalize_for_net_http!(env)
     req = Request.new(env)
-    Aws::Signers::V4.new(@credentials, @service_name, @region).sign(req)
+    Aws::Sigv4::Signer.new(credentials: @credentials, service: @service_name, region: @region).sign_request(req)
     @app.call(env)
   end
 


### PR DESCRIPTION
The `aws-sdk-resources` gem includes a bunch of service-specific gems. This gem only needs `aws-sdk-core` which includes `aws-sigv4` and the seahorse code.

I updated what I could, but got stuck getting the tests passing. I hope this gives a good starting point for v0.2.x branch.