### PR TITLE
Removing Accept-Encoding header & bump version to 0.1.9

### DIFF
--- a/faraday_middleware-aws-signers-v4.gemspec
+++ b/faraday_middleware-aws-signers-v4.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = 'faraday_middleware-aws-signers-v4'
-  spec.version       = '0.1.8'
+  spec.version       = '0.1.9'
   spec.authors       = ['Genki Sugawara']
   spec.email         = ['sgwr_dts@yahoo.co.jp']
 

--- a/lib/faraday_middleware/request/aws_signers_v4.rb
+++ b/lib/faraday_middleware/request/aws_signers_v4.rb
@@ -66,10 +66,6 @@ class FaradayMiddleware::AwsSignersV4 < Faraday::Middleware
   def normalize_for_net_http!(env)
     return unless @net_http
 
-    if Net::HTTP::HAVE_ZLIB
-      env.request_headers['Accept-Encoding'] ||= 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
-    end
-
     env.request_headers['Accept'] ||= '*/*'
   end
 end

--- a/spec/faraday_middleware/aws_signers_v4_spec.rb
+++ b/spec/faraday_middleware/aws_signers_v4_spec.rb
@@ -90,11 +90,11 @@ describe FaradayMiddleware::AwsSignersV4 do
     subject { client.get('/account').body }
 
     let(:signature) do
-      'f3e76cef7d271786b6a35d02de70bafd9e0e5f7c50de9c17f9b7dc73f105f841'
+      'c09b39e34c45c4915dfebdff57b4096ab30363558b6bcb94e0489ef0bfd1bd89'
     end
 
     let(:signed_headers) do
-      'accept-encoding;host;x-amz-content-sha256;x-amz-date'
+      'host;x-amz-content-sha256;x-amz-date'
     end
 
     let(:additional_expected_headers) do

--- a/spec/faraday_middleware/aws_signers_v4_spec.rb
+++ b/spec/faraday_middleware/aws_signers_v4_spec.rb
@@ -98,8 +98,7 @@ describe FaradayMiddleware::AwsSignersV4 do
     end
 
     let(:additional_expected_headers) do
-      {"Accept"=>"*/*",
-       "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"}
+      {"Accept"=>"*/*"}
     end
 
     before do


### PR DESCRIPTION
This plugin asks for compressed content, but it doesn't have code to dompress it,
which is cusing issues to some of the consumers of this library.

Related: https://github.com/winebarrel/faraday_middleware-aws-signers-v4/issues/13