### PR TITLE
Remove net/http normalization

### DIFF
--- a/lib/faraday_middleware/request/aws_signers_v4.rb
+++ b/lib/faraday_middleware/request/aws_signers_v4.rb
@@ -47,24 +47,11 @@ class FaradayMiddleware::AwsSignersV4 < Faraday::Middleware
     @credentials = options.fetch(:credentials)
     @service_name = options.fetch(:service_name)
     @region = options.fetch(:region)
-    @net_http = net_http?(app)
   end
 
   def call(env)
-    normalize_for_net_http!(env)
     req = Request.new(env)
     Aws::Signers::V4.new(@credentials, @service_name, @region).sign(req)
     @app.call(env)
-  end
-
-  private
-
-  def net_http?(app)
-    app.is_a?(Faraday::Adapter::NetHttp)
-  end
-
-  def normalize_for_net_http!(env)
-    return unless @net_http
-    env.request_headers['Accept'] ||= '*/*'
   end
 end

--- a/spec/faraday_middleware/aws_signers_v4_spec.rb
+++ b/spec/faraday_middleware/aws_signers_v4_spec.rb
@@ -86,28 +86,6 @@ describe FaradayMiddleware::AwsSignersV4 do
     end
   end
 
-  context 'use net/http' do
-    subject { client.get('/account').body }
-
-    let(:signature) do
-      'c09b39e34c45c4915dfebdff57b4096ab30363558b6bcb94e0489ef0bfd1bd89'
-    end
-
-    let(:signed_headers) do
-      'host;x-amz-content-sha256;x-amz-date'
-    end
-
-    let(:additional_expected_headers) do
-      {"Accept"=>"*/*"}
-    end
-
-    before do
-      expect_any_instance_of(FaradayMiddleware::AwsSignersV4).to receive(:net_http?) { true }
-    end
-
-    it { is_expected.to eq response }
-  end
-
   context 'with InstanceProfileCredentials' do
     let(:security_credentials_url) { 'http://169.254.169.254/latest/meta-data/iam/security-credentials/' }
 


### PR DESCRIPTION
Since `net/http` automatically adds `Accept`/`AcceptEncoding` headers, I thought that it was necessary to add it to the signature.

However it seems unnecessary..
https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

> 5. Add the signed headers, followed by a newline character. This value is the list of headers that you included in the canonical headers. By adding this list of headers, you tell AWS which headers in the request are part of the signing process and which ones AWS can ignore (for example, any additional headers added by a proxy) for purposes of validating the request.

So I will delete this unnecessary process.
